### PR TITLE
use Buffer.from method as Buffer() is deprecated

### DIFF
--- a/src/sha256.js
+++ b/src/sha256.js
@@ -95,7 +95,7 @@
       }
       if (Array.isArray(message) || ArrayBuffer.isView(message) ||
         message.constructor === Buffer) {
-        return crypto.createHash(algorithm).update(new Buffer(message)).digest('hex');
+        return crypto.createHash(algorithm).update(new Buffer.from(message)).digest('hex');
       } else {
         return method(message);
       }


### PR DESCRIPTION
use Buffer.from method as Buffer() is deprecated due to security and usability issues