### PR TITLE
Fix NodeJS check for electron renderer

### DIFF
--- a/src/sha256.js
+++ b/src/sha256.js
@@ -17,7 +17,7 @@
     WINDOW = false;
   }
   var WEB_WORKER = !WINDOW && typeof self === 'object';
-  var NODE_JS = !root.JS_SHA256_NO_NODE_JS && typeof process === 'object' && process.versions && process.versions.node;
+  var NODE_JS = !root.JS_SHA256_NO_NODE_JS && typeof process === 'object' && process.versions && process.versions.node && process.type != 'renderer';
   if (NODE_JS) {
     root = global;
   } else if (WEB_WORKER) {


### PR DESCRIPTION
PR fixes a bug in the `NODE_JS` check where it currently returns true when running in electron renderer with `nodeIntegrationInWorker: true` set. We can use [`process.type`](https://www.electronjs.org/docs/latest/api/process#processtype-readonly) property which Electron sets to determine if we're running in the renderer process vs regular Node.