### PR TITLE
Fix uploading coverage to coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,10 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Upload to coveralls
-        run: |
-          npm install coveralls
-          npm run coveralls
+      - name: Generate coverage report
+        run: npm run coverage
 
+      - name: Upload to coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: ./coverage.lcov

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /coverage/
 /.nyc_output/
+/coverage.lcov

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "nyc mocha tests/node-test.js",
     "report": "nyc --reporter=html --reporter=text mocha tests/node-test.js",
-    "coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "coverage": "nyc report --reporter=text-lcov > coverage.lcov",
     "build": "uglifyjs src/sha256.js -c -m eval --comments -o build/sha256.min.js"
   },
   "repository": {


### PR DESCRIPTION
PR attempts to fix uploading to coveralls for the repo by switching from the [third-party npm package](https://www.npmjs.com/package/coveralls) for coveralls to the [first-party GHA coveralls action](https://github.com/coverallsapp/github-action).

The npm package has long been abandoned, and that using it with GHA requires you to generate a token on coveralls, add it as a secret here, and then pass it in as an environment variable. The action on the other hand is supported, and shouldn't require any configuration in regards to tokens and should just work out of the box.

From the action, it looks like the job was successfully uploaded to coveralls: https://coveralls.io/builds/73905020